### PR TITLE
export_upfiles now exports uploaded files (not just the directory) in ZIPs

### DIFF
--- a/forum_modules/exporter/exporter.py
+++ b/forum_modules/exporter/exporter.py
@@ -241,9 +241,13 @@ def export_upfiles(tf):
     folder = str(settings.UPFILES_FOLDER)
 
     if os.path.exists(folder):
-        if isinstance(tf, zipfile.ZipFile):
+        if isinstance(tf, zipfile.ZipFile):  ## zipfile is not recursive
             tf.write(folder, arcname='/upfiles')
-        else:
+            for filename in os.listdir(folder):
+                path = os.path.join(folder, filename)
+                if os.path.isfile(path):  ## skip . & ..
+                    do(path, arcname='/upfiles/' + filename)
+        else:  ## tarfile is automatically recursive
             tf.add(folder, arcname='/upfiles')
 
 


### PR DESCRIPTION
Closes #514.

This patch doesn't fix `export_skinsfolder`, which would require an `os.walk`.